### PR TITLE
fix: install commands, expose devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ services:
     ports:
     - 5000:5000 #Web Caller Port
     - 8079:8079 #Host Port
-    privileged: true
+    devices:
+    - /dev/snd:/dev/snd
     environment:
       #required settings
       AUTODARTS_EMAIL:    '' #Your autodarts mail adress
@@ -108,7 +109,8 @@ services:
     ports:
     - 5000:5000 #Web Caller Port
     - 8079:8079 #Host Port
-    privileged: true
+    devices:
+    - /dev/snd:/dev/snd
     env_files:
     - .env
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,10 @@ COPY --from=build /autodarts-caller* ./autodarts-caller
 COPY ./entrypoint.sh ./entrypoint.sh
 RUN chmod +x autodarts-caller && \
     chmod +x entrypoint.sh && \
-    apk add glib
+    apt update && \
+    apt install -y libglib2.0-0 alsa-utils && \
+    rm -rf /var/lib/apt/lists/*
+
 EXPOSE 5000 8079
 
 CMD ./entrypoint.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,8 @@ services:
     ports:
     - 5000:5000 #Web Caller Port
     - 8079:8079 #Host Port
-    privileged: true
+    devices:
+    - /dev/snd:/dev/snd
     environment:
       #required settings
       AUTODARTS_EMAIL:    '' #Your autodarts mail adress
@@ -47,6 +48,4 @@ services:
       MIXER_BUFFERSIZE:
 
     volumes:
-    - ./autodarts-caller/media:/usr/share/autodarts-caller/media
-    - ./autodarts-caller/media-shared:/usr/share/autodarts-caller/media-shared
     - ./autodarts-caller:/usr/share/autodarts-caller

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,9 +11,11 @@ if [ -n "$AUTODARTS_BOARD_ID" ]; then
 fi
 if [ -n "$MEDIA_PATH" ]; then
   args="$args -M $MEDIA_PATH"
+  mkdir -p $MEDIA_PATH
 fi
 if [ -n "$MEDIA_PATH_SHARED" ]; then
   args="$args -MS $MEDIA_PATH_SHARED"
+  mkdir -p $MEDIA_PATH_SHARED
 fi
 if [ -n "$CALLER_VOLUME" ]; then
   args="$args -V $CALLER_VOLUME"


### PR DESCRIPTION
this resolves the build issues.

There was a left over apk install from when I was using alpine images.

It also adds the exposure of the sound devices to the readme and sample docker-compose

Also, it proposes to share a single folder as a volume and then create the media folders if they do not exist