### PR TITLE
fix: compose example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,8 @@ services:
     ports:
     - 5000:5000 #Web Caller Port
     - 8079:8079 #Host Port
-    privileged: true
+    devices:
+    - /dev/snd:/dev/snd
     environment:
       #required settings
       AUTODARTS_EMAIL:    '' #Your autodarts mail adress


### PR DESCRIPTION
fixed the compose example in the readme to pass the sound device to the container instead of using privileged

this was already in the compose file but missed in the readme