### PR TITLE
fix: latest tag in docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-            latest
+            type=semver,pattern={{major}}.{{minor}},value=latest
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,10 +152,11 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-            type=semver,pattern={{major}}.{{minor}},value=latest
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=latest
 
       - name: Build and push
         uses: docker/build-push-action@v4


### PR DESCRIPTION
This PR ensures that the latest tag only gets set if the tag is not a pre-release version