### PR TITLE
fix: also call single darts in second leg in ATC and RTW

### DIFF
--- a/autodarts-caller.py
+++ b/autodarts-caller.py
@@ -1977,6 +1977,7 @@ def process_match_atc(m):
         currentTarget = m['state']['targets'][currentPlayerIndex][int(currentTargetsPlayer) -1]
 
     if turns is not None and turns['throws']:
+        isGameFinished = False
         lastThrow = turns['throws'][-1]
         targetHit = lastThrow['segment']['number']
 
@@ -2073,6 +2074,9 @@ def process_match_rtw(m):
 
     gameon = (0 == m['gameScores'][0] and turn['throws'] == [])
     matchover = (winningPlayerIndex != -1 and isGameFinished == False)
+    
+    if turn is not None and turn['throws']:
+        isGameFinished = False
 
     # Darts pulled (Playerchange and Possible-checkout)
     if gameon == False and turn != None and turn['throws'] == [] or isGameFinished == True:


### PR DESCRIPTION
This PR fixes the issue that isGameFinished never got reset for ATC and RTW.

In RTW, this resulted in single darts not getting called on the second leg