### PR TITLE
Added "Tactics" Game-Mode for "Cricket"-Game to darts-caller.py

### DIFF
--- a/darts-caller.py
+++ b/darts-caller.py
@@ -2121,14 +2121,7 @@ def process_match_tactics(m):
     currentPlayerIsBot = (m['players'][currentPlayerIndex]['cpuPPR'] is not None)
     turns = m['turns'][0]
     variant = m['variant']
-    settings = m['settings']
-    gamemode = settings['gameMode']
-
-    if gamemode == "Tactics":
-        logger.critical(f"2172 - Variant: {variant} - GameMode: {gamemode}")
-
-    # ppi(gamemode)
-
+    
     isGameOn = False
     isGameFin = False
     global isGameFinished


### PR DESCRIPTION
Quick and Dirty Extension for game-mode "Tactics" in "Cricket" game.

- Adding Variable "SUPPORTED_TACTICS_FIELDS"  (Extended SUPPORTED_CRICKET_FIELDS for additional fields)

- Adding Function "process_match_tactics" (duplicate of "process_match_cricket") - SUPPORTED_CRICKET_FIELDS replaced for SUPPORTED_TACTICS_FIELDS